### PR TITLE
Use PatchOperationSet to avoid conflicts with other mods

### DIFF
--- a/1.3/Patches/Various_Patches.xml
+++ b/1.3/Patches/Various_Patches.xml
@@ -57,7 +57,7 @@
   </Operation>
   
   <!--Add terror radius display-->
-  <Operation Class="PatchOperationAdd">
+  <Operation Class="PatchOperationSet">
     <xpath>/Defs/ThingDef[defName="SculptureTerror" or defName="Skullspike" or defName="GibbetCage"]</xpath>
     <value>
     <specialDisplayRadius>5</specialDisplayRadius>


### PR DESCRIPTION
I'm getting an error in my logs telling me that multiple mods are adding the same value to `SculptureTerror`. I'm not sure what other mod is conflicting, but using `PatchOperationSet` should avoid the error.